### PR TITLE
Giving wf access to Swach Admin

### DIFF
--- a/data/pb/ACCESSCONTROL-ROLEACTIONS/roleactions.json
+++ b/data/pb/ACCESSCONTROL-ROLEACTIONS/roleactions.json
@@ -58428,6 +58428,12 @@
       "actionid": 23451576,
       "actioncode": "",
       "tenantId": "pb"
+    },
+    {
+      "rolecode": "SWACH_ADMIN",
+      "actionid": 1755,
+      "actioncode": "",
+      "tenantid": "pb"
     }
     
   ]


### PR DESCRIPTION
In ACCESSCONTROL-ROLEACTIONS/roleactions.json given access of /egov-workflow-v2/egov-wf/businessservice/_search to SWACH_ADMIN role.